### PR TITLE
fix: transactions overflow

### DIFF
--- a/client/src/components/transactions/TransactionDaily.jsx
+++ b/client/src/components/transactions/TransactionDaily.jsx
@@ -1,39 +1,39 @@
 import React, { useState, useEffect } from "react";
 import TransactionSingle from "./TransactionSingle";
 import { protectedRoute } from "../../apiClient/axiosInstance";
-import formatNumWithCommas from "../../utility/formatNumWithCommas"
+import formatNumWithCommas from "../../utility/formatNumWithCommas";
 import TransactionSingleTransfer from "./TransactionSingleTransfer";
 
 const TransactionDaily = ({ date, day, netIncome }) => {
-  const [income, setIncome] = useState(0)
-  const [expense, setExpense] = useState(0)
-  const [net, setNet] = useState(0)
-  const [transactions, setTransactions] = useState([])
+  const [income, setIncome] = useState(0);
+  const [expense, setExpense] = useState(0);
+  const [net, setNet] = useState(0);
+  const [transactions, setTransactions] = useState([]);
 
   const formattedDate = new Date(date).getDate().toString().padStart(2, "0");
-  console.log("params date 2", date)
+  console.log("params date 2", date);
   useEffect(() => {
-      protectedRoute.get("/transactions/getTransactions", {
+    protectedRoute
+      .get("/transactions/getTransactions", {
         params: {
-          period: 'day',
+          period: "day",
           year: new Date(date).getFullYear(),
           month: new Date(date).getMonth() + 1,
-          day: day
-        }
+          day: day,
+        },
       })
       .then((response) => {
-        console.log("transactions for the this day", response.data)
-        const {data} = response
-        setTransactions(data)
+        console.log("transactions for the this day", response.data);
+        const { data } = response;
+        setTransactions(data);
       })
       .catch((error) => {
-        console.log(error)
-      })
-  }, [])
+        console.log(error);
+      });
+  }, []);
   const [isOpen, setIsOpen] = useState(false);
 
   // Format date to be always 2 digits
-  
 
   // Get the abbreviated day (e.g., Sun for Sunday)
   const abbreviatedDay = new Date(date).toLocaleString("en-us", {
@@ -51,36 +51,39 @@ const TransactionDaily = ({ date, day, netIncome }) => {
     setIsOpen(!isOpen);
   };
 
-  function renderTransacSingle(transaction){
-    if(transaction.type != 'transfer'){
-      return <TransactionSingle
-            key={transaction.id}
-            category={transaction.category.name}
-            //name={"klsjaf"}
-            account={transaction.account.name}
-            description={transaction.note}
-            amount={transaction.amount}
-            transactionType={transaction.type}
-          />
-    }
-    else if(transaction.type == 'transfer'){
-      return <TransactionSingleTransfer 
-        fromAccount={transaction.fromAccount.name}
-        toAccount={transaction.toAccount.name}
-        description={transaction.note}
-        amount={transaction.amount}
-      />
+  function renderTransacSingle(transaction) {
+    if (transaction.type != "transfer") {
+      return (
+        <TransactionSingle
+          key={transaction.id}
+          category={transaction.category.name}
+          //name={"klsjaf"}
+          account={transaction.account.name}
+          description={transaction.note}
+          amount={transaction.amount}
+          transactionType={transaction.type}
+        />
+      );
+    } else if (transaction.type == "transfer") {
+      return (
+        <TransactionSingleTransfer
+          fromAccount={transaction.fromAccount.name}
+          toAccount={transaction.toAccount.name}
+          description={transaction.note}
+          amount={transaction.amount}
+        />
+      );
     }
   }
 
   return (
     <div>
-      <div className="daily-container flex justify-between items-center p-2 border-b border-b-gray-400">
+      <div className="daily-container flex justify-between items-center p-2 border-b border-b-gray-400 ">
         <div className="trans-left flex flex-col items-center">
           <h2 className="text-xl font-semibold">{formattedDate}</h2>
           <h2>{abbreviatedDay}</h2>
         </div>
-        <div className="trans-right flex justify-center items-center">
+        <div className="trans-right flex justify-center items-center ">
           <h2
             className={`net-income mr-4 font-medium text-lg ${getNetIncomeClass(
               netIncome
@@ -99,13 +102,15 @@ const TransactionDaily = ({ date, day, netIncome }) => {
       </div>
 
       {isOpen && (
-        <div className="transaction-details border-b border-gray-400">
-          {(transactions.length !== 0)?transactions.map((transaction, index) => (
-            //console.log("single transaction", transaction)
-            renderTransacSingle(transaction)
-          ))
-          : <p>No transactions for this day</p>
-        }
+        <div className="transaction-details border-b border-gray-400 max-h-64 overflow-y-auto">
+          {transactions.length !== 0 ? (
+            transactions.map((transaction, index) =>
+              //console.log("single transaction", transaction)
+              renderTransacSingle(transaction)
+            )
+          ) : (
+            <p>No transactions for this day</p>
+          )}
         </div>
       )}
     </div>

--- a/client/src/pages/TransactionsPage.jsx
+++ b/client/src/pages/TransactionsPage.jsx
@@ -8,9 +8,6 @@ import TransactionDailyContainer from "../components/transactions/TransactionDai
 import TransactionWeekly from "../components/transactions/TransactionWeekly";
 import TransactionMonthly from "../components/transactions/TransactionMonthly";
 
-
-
-
 function getDaysInMonth(year, month) {
   //month of date constructor is 0 based. passing a 1-based month parameter to getDaysInMonth
   //and setting day to 0 causes the date to roll over to the last day of the month we want
@@ -23,29 +20,28 @@ function getWeeksInMonth(year, month) {
   const firstDayOfMonth = new Date(year, month - 1, 1);
   const firstDayWeekday = firstDayOfMonth.getDay(); // Day of the week (0 = Sunday)
 
-    // Get the last day of the month
+  // Get the last day of the month
   const lastDayOfMonth = new Date(year, month, 0); // Automatically gets the last day
   const lastDay = lastDayOfMonth.getDate(); // Number of days in the month
   const lastDayWeekday = lastDayOfMonth.getDay();
 
-    // Calculate the total number of days spanned by weeks
+  // Calculate the total number of days spanned by weeks
   const totalDays = lastDay + firstDayWeekday; // Offset for the first week
 
-    // Calculate the number of weeks, rounding up for partial weeks
+  // Calculate the number of weeks, rounding up for partial weeks
   const numWeeks = Math.ceil(totalDays / 7);
 
   return numWeeks;
 }
 
-
 const TransactionsPage = () => {
   const [date, setDate] = useState({ month: 11, year: 2024 }); // Default: December 2024 (0-indexed months)
   const [activeTab, setActiveTab] = useState(0); // State to manage active tab
-  const [renderJSX, setRenderJSX] = useState([])
+  const [renderJSX, setRenderJSX] = useState([]);
 
   useEffect(() => {
-    setDaysInMonth(getDaysInMonth(date.year, date.month))
-  }, [date])
+    setDaysInMonth(getDaysInMonth(date.year, date.month));
+  }, [date]);
 
   const months = [
     "January",
@@ -62,8 +58,12 @@ const TransactionsPage = () => {
     "December",
   ];
 
-  const [daysInMonth, setDaysInMonth] = useState(getDaysInMonth(date.year, date.month))
-  const [weeksInMonth, setWeeksInMonth] = useState(getWeeksInMonth(date.year, date.month))
+  const [daysInMonth, setDaysInMonth] = useState(
+    getDaysInMonth(date.year, date.month)
+  );
+  const [weeksInMonth, setWeeksInMonth] = useState(
+    getWeeksInMonth(date.year, date.month)
+  );
 
   const handlePrevMonth = () => {
     setDate((prev) => {
@@ -91,15 +91,14 @@ const TransactionsPage = () => {
     setActiveTab(index);
   };
 
-
   function renderContent() {
-    switch(activeTab){
+    switch (activeTab) {
       case 0:
-        return <TransactionDailyContainer date={date}/>
+        return <TransactionDailyContainer date={date} />;
       case 1:
         break;
       default:
-        break
+        break;
     }
     // if (activeTab === 0) {
     //   // for(let x = daysInMonth; x >= 1; x--){
@@ -113,18 +112,14 @@ const TransactionsPage = () => {
     //   //     />
     //   //   );
     //   // }
-      
-    // } 
-    
-    
+
+    // }
 
     // setRenderJSX(retJSX)
   }
 
-  
-
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col min-h-screen">
       <TaskBar />
       <div className="flex-1 md:ml-[20%] lg:ml-[16.666%] page-with-taskbar">
         <PageHeader
@@ -203,9 +198,7 @@ const TransactionsPage = () => {
             </div>
 
             <div role="tabpanel" className="content-tab">
-              {
-                renderContent()
-              }
+              {renderContent()}
             </div>
 
             {/*uncomment below code and comment above code if fetches dont work */}


### PR DESCRIPTION
fixed overflow issue in transactions when there are enough components being rendered, the background does not fit

additional changes:
+ if user has enough transactions in a given day, the drop down will be scrollable

![image](https://github.com/user-attachments/assets/7f24abc8-0181-4851-9957-50d4fd3a9698)
